### PR TITLE
Completed polish on navpane, including:

### DIFF
--- a/AzureBlog/AzureBlog/App.xaml.cs
+++ b/AzureBlog/AzureBlog/App.xaml.cs
@@ -67,6 +67,9 @@ namespace AzureBlog
                 titleBar.ButtonBackgroundColor = titleBarColor;
             }
 
+            // retrieve the newspaper contents from the disk and get the latest articles from the web
+            this.RefreshNewspaperAsync();
+
             AppShell shell = Window.Current.Content as AppShell;
 
             // Do not repeat app initialization when the Window already has content,
@@ -80,8 +83,6 @@ namespace AzureBlog
                 shell.Language = Windows.Globalization.ApplicationLanguages.Languages[0];
 
                 shell.AppFrame.NavigationFailed += OnNavigationFailed;
-
-                this.RefreshNewspaperAsync();
 
                 if (e.PreviousExecutionState == ApplicationExecutionState.Terminated)
                 {

--- a/AzureBlog/AzureBlog/AppShell.xaml
+++ b/AzureBlog/AzureBlog/AppShell.xaml
@@ -106,21 +106,24 @@
                                Grid.ColumnSpan="3"
                                Height="1"
                                Fill="{ThemeResource SystemControlForegroundBaseLowBrush}"
-                               Margin="16,0,16,6"/>
+                               Margin="16,0,16,6"
+                               Visibility="Collapsed"/>
                     <Button x:Name="FeedbackNavPaneButton"
                             Grid.Row="2"
                             Grid.Column="1"
                             Style="{StaticResource SplitViewPaneButtonStyle}"
                             Content="&#xE76E;"
                             AutomationProperties.Name="Feedback"
-                            ToolTipService.ToolTip="Feedback"/>
+                            ToolTipService.ToolTip="Feedback"
+                            Visibility="Collapsed"/>
                     <Button x:Name="SettingsNavPaneButton"
                             Grid.Row="2"
                             Grid.Column="2"
                             Style="{StaticResource SplitViewPaneButtonStyle}"
                             Content="&#xE713;"
                             AutomationProperties.Name="Settings"
-                            ToolTipService.ToolTip="Settings"/>
+                            ToolTipService.ToolTip="Settings"
+                            Visibility="Collapsed"/>
                 </Grid>
             </SplitView.Pane>
 

--- a/AzureBlog/AzureBlog/AppShell.xaml.cs
+++ b/AzureBlog/AzureBlog/AppShell.xaml.cs
@@ -59,7 +59,7 @@ namespace AzureBlog
                 new NavMenuItem()
                 {
                     Symbol = Symbol.Home,
-                    Label = "News Items",
+                    Label = "News Articles",
                     DestPage = typeof(NewspaperPage)
                 },
 
@@ -263,6 +263,14 @@ namespace AzureBlog
                 NavMenuList.SetSelectedItem(container);
                 if (container != null) container.IsTabStop = true;
             }
+            // if the page being navigated to is the NewspaperPage (at index 0 in the NavMenuList), then
+            // set the selected index in the NavMenuList to the be NespaperPage item (which is at index 0).
+            // This sets the selected item in the NavMenuList correctly when the app first loads.
+            else if (e.NavigationMode == NavigationMode.New && e.SourcePageType == typeof(NewspaperPage))
+            {
+                this.NavMenuList.SelectedIndex = 0;
+            }
+
         }
 
         private void OnNavigatedToPage(object sender, NavigationEventArgs e)

--- a/AzureBlog/AzureBlog/Package.appxmanifest
+++ b/AzureBlog/AzureBlog/Package.appxmanifest
@@ -1,48 +1,27 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
-<Package
-  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
-  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
-  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-  IgnorableNamespaces="uap mp">
-
-  <Identity
-    Name="976cbb5c-c680-4c4d-949a-05b77803af0a"
-    Publisher="CN=simonbro"
-    Version="1.0.0.0" />
-
-  <mp:PhoneIdentity PhoneProductId="976cbb5c-c680-4c4d-949a-05b77803af0a" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
-
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
+  <Identity Name="976cbb5c-c680-4c4d-949a-05b77803af0a" Publisher="CN=simonbro" Version="1.0.0.0" />
+  <mp:PhoneIdentity PhoneProductId="976cbb5c-c680-4c4d-949a-05b77803af0a" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>AzureBlog</DisplayName>
     <PublisherDisplayName>simonbro</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
-
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
   </Dependencies>
-
   <Resources>
-    <Resource Language="x-generate"/>
+    <Resource Language="x-generate" />
   </Resources>
-
   <Applications>
-    <Application Id="App"
-      Executable="$targetnametoken$.exe"
-      EntryPoint="AzureBlog.App">
-      <uap:VisualElements
-        DisplayName="AzureBlog"
-        Square150x150Logo="Assets\Square150x150Logo.png"
-        Square44x44Logo="Assets\Square44x44Logo.png"
-        Description="AzureBlog"
-        BackgroundColor="transparent">
-        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png"/>
+    <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="AzureBlog.App">
+      <uap:VisualElements DisplayName="Azure News Reader" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" Description="AzureBlog" BackgroundColor="transparent">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png">
+        </uap:DefaultTile>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
     </Application>
   </Applications>
-
   <Capabilities>
     <Capability Name="internetClient" />
   </Capabilities>

--- a/AzureBlog/AzureBlog/Styles/Styles.xaml
+++ b/AzureBlog/AzureBlog/Styles/Styles.xaml
@@ -282,13 +282,13 @@
                                                          Duration="0"
                                                          To="1"/>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderBackground" Storyboard.TargetProperty="Fill">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Transparent" />
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemColorHighlightColor}" />
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderBackground" Storyboard.TargetProperty="Stroke">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlForegroundAccentBrush}" />
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemColorHighlightColor}" />
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlForegroundAccentBrush}" />
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemColorHighlightTextColor}" />
                                         </ObjectAnimationUsingKeyFrames>
                                         <PointerUpThemeAnimation Storyboard.TargetName="ContentPresenter" />
                                     </Storyboard>
@@ -302,7 +302,7 @@
                                         <DoubleAnimation Storyboard.TargetName="SelectedPipe"
                                                          Storyboard.TargetProperty="Opacity"
                                                          Duration="0"
-                                                         To="1"/>
+                                                         To="0"/>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderBackground" Storyboard.TargetProperty="Fill">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightListLowBrush}" />
                                         </ObjectAnimationUsingKeyFrames>
@@ -374,7 +374,7 @@
                                    Opacity="0"
                                    Width="4"
                                    Height="24"
-                                   Fill="{ThemeResource SystemControlForegroundAccentBrush}"
+                                   Fill="{ThemeResource SystemColorHighlightColor}"
                                    Margin="{TemplateBinding Padding}"
                                    VerticalAlignment="Center"
                                    HorizontalAlignment="Left"/>


### PR DESCRIPTION
- change "News Items" to "News Articles"
- "News Articles" now appears selected when app opens
- settings and feedback buttons are now collapsed (i.e. invisible) as they are not implemented yet
- app name change to "Azure News Reader" from "AzureBlog"
- selected item in navpane is fully coloured in, rather than just a vertical selection bar
- newspaper refresh is now earlier in app start up cycle: now refreshes before AppShell is instantiated

OneNote updated: "Nav Pane Polish" page now moved to "Completed Items" section
