### PR TITLE
Updated article view size and transitions

### DIFF
--- a/AzureBlog/AzureBlog/Views/NewspaperPage.xaml
+++ b/AzureBlog/AzureBlog/Views/NewspaperPage.xaml
@@ -19,7 +19,7 @@
 
             <GridView.ItemTemplate>
                 <DataTemplate x:DataType="models:Article">
-                    <Grid x:Name="ArticleGrid" Background="#FF939598" Margin="15,15,0,0">
+                    <Grid x:Name="ArticleGrid" Background="#FF939598" Margin="15,15,0,0" Height="320">
                         <Image Source="{x:Bind ImageUriString}" Stretch="UniformToFill"/>
                         <StackPanel Orientation="Vertical" Background="#CC000000" Margin="3,0,3,4" Height="130" VerticalAlignment="Bottom">
                             <TextBlock Text="{x:Bind Title}" FontSize="22" Foreground="White" Margin="10,4,10,0" Height="60" LineHeight="0" TextWrapping="Wrap" TextTrimming="WordEllipsis" HorizontalAlignment="Left"/>
@@ -31,6 +31,13 @@
 
                 </DataTemplate>
             </GridView.ItemTemplate>
+
+            <GridView.ItemContainerTransitions>
+                <TransitionCollection>
+                    <RepositionThemeTransition />
+                </TransitionCollection>    
+            </GridView.ItemContainerTransitions>
+            
         </GridView>
     </Grid>
 </Page>


### PR DESCRIPTION
- fixed size of article within the grid when no article image is present
- made the transitions of the articles nice when resizing the newspaper page
